### PR TITLE
Fix header logos and enable DCM format-comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.2
+- Enabled `format-comment`; issues with it were fixed.
+
 # 1.1.1
 - Configure `prefer-static-class` DCM rule exceptions for hooks and providers.
 - Disabled `format-comment` because of https://github.com/dart-code-checker/dart-code-metrics/issues/1158.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # netglade analysis
 
-[![netglade][netglade_logo_light]][netglade_link_light]
-[![netglade][netglade_logo_dark]][netglade_link_dark]
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/netglade/.github/main/assets/netglade_logo_light.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/netglade/.github/main/assets/netglade_logo_dark.png">
+  <img alt="netglade" src="https://raw.githubusercontent.com/netglade/.github/main/assets/netglade_logo_dark.png">
+</picture>
 
 Developed with 💚 by [netglade][netglade_link]
 
@@ -32,7 +35,7 @@ Then, add an include in `analysis_options.yaml`:
 include: package:netglade_analysis/lints.yaml
 ```
 
-To also use [Dart Code Metrics](https://dcm.dev), add configuration in `analysis_options.yaml` (and add `dart_code_metrics` to dev dependencies):  
+To also use [Dart Code Metrics](https://dcm.dev), add configuration in `analysis_options.yaml` (and add `dart_code_metrics` to dev dependencies):
 
 ```yaml
 analyzer:
@@ -54,10 +57,6 @@ To indicate your project is using `netglade_analysis` →
 ```
 
 [netglade_link]: https://netglade.cz/en
-[netglade_link_light]: https://netglade.cz/en#gh-dark-mode-only
-[netglade_link_dark]: https://netglade.cz/en#gh-light-mode-only
-[netglade_logo_light]: https://raw.githubusercontent.com/netglade/.github/main/assets/netglade_logo_light.png#gh-dark-mode-only
-[netglade_logo_dark]: https://raw.githubusercontent.com/netglade/.github/main/assets/netglade_logo_dark.png#gh-light-mode-only
 
 [ci_badge]: https://github.com/netglade/netglade_analysis/workflows/ci/badge.svg
 [ci_badge_link]: https://github.com/netglade/netglade_analysis/actions

--- a/lib/dcm.yaml
+++ b/lib/dcm.yaml
@@ -32,7 +32,7 @@ dart_code_metrics:
     # - ban-name
     - binary-expression-operand-order
     - double-literal-format
-    # - format-comment # waiting for https://github.com/dart-code-checker/dart-code-metrics/issues/1158
+    - format-comment
     - list-all-equatable-fields
     - member-ordering:
         # alphabetize: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: netglade_analysis
-version: 1.1.1
+version: 1.1.2
 description: Lint rules for Dart and Flutter used internally at netglade.
 repository: https://github.com/netglade/netglade_analysis
 issue_tracker: https://github.com/netglade/netglade_analysis/issues


### PR DESCRIPTION
- Fixed logos so it aligns with updated GitHub docs. https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to
- Enabled DCM `format-comment` again.